### PR TITLE
fix: Update release-please configuration for Terraform and Terragrunt

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,3 +30,7 @@ dx:
 github:
   - changed-files:
       any-glob-to-any-file: ['.github/**/*']
+
+cd:
+  - changed-files:
+      any-glob-to-any-file: ['@release-please-config.json', '@.release-please-manifest.json']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: terraform
+          release-type: simple
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,18 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
-    "tools/infractl": {
-      "release-type": "go",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
-    },
     "infra/terraform": {
-      "release-type": "terraform",
+      "release-type": "simple",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     },
     "infra/terragrunt": {
-      "release-type": "terraform",
+      "release-type": "simple",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     }


### PR DESCRIPTION
## 🏗️ Terragrunt Reference Architecture PR

### What Changes

- The release-please configuration for the `infra/terraform` and `infra/terragrunt` packages has been updated.
- The release-type has been changed from `terraform` to `simple`.
- The `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` options have been retained.
- The configuration for the `tools/infractl` package has been removed, as it is no longer needed.
- The corresponding change has been made in the `.github/workflows/release.yml` file, where the `release-type` has been updated to `simple`.

### Change Type (select all that apply)

- [x] Terragrunt Configuration
- [x] Shared Configuration
- [ ] Environment Configuration
- [ ] Terraform Module
- [ ] Documentation
- [ ] Dependency Update

### Checklist

- [x] Followed Terragrunt best practices
- [x] Maintained configuration modularity
- [ ] Added/updated tests
- [ ] Updated documentation
- [x] Verified cross-environment compatibility
- [x] Ensured DRY (Don't Repeat Yourself) principles

### Configuration Impact

- The changes in this PR will affect the release process for the `infra/terraform` and `infra/terragrunt` packages.
- There are no potential breaking changes.
- The changes are expected to have a positive impact on the release process, making it more streamlined and efficient.

### Additional Context

- This PR is related to the ongoing efforts to improve the release management process for the Terragrunt Reference Architecture.