### PR TITLE
feat: Improve Terragrunt command execution with auto-approve for apply and destroy

### DIFF
--- a/infra/terragrunt/_shared/_units/README.md
+++ b/infra/terragrunt/_shared/_units/README.md
@@ -4,6 +4,16 @@
 
 This directory contains shared infrastructure unit configurations that provide a modular, flexible, and standardized approach to defining infrastructure components across different environments and modules.
 
+```txt
+infra/terragrunt/
+├── _shared/
+│   ├── _config/
+│   ├── _units/
+│   │   └── <unit>.hcl # unit referenced in the consuming unit's terragrunt.hcl (path pattern: infra/terragrunt/<env>/<stack>/<unit>/terragrunt.hcl)
+│   └── README.md
+```
+
+
 ## Architecture Principles 🏗️
 
 ### Core Design Concepts
@@ -17,166 +27,79 @@ This directory contains shared infrastructure unit configurations that provide a
 
 ### 1. Module Source Management
 
-Implements a sophisticated, flexible module sourcing mechanism:
+Automatically reads the environment configuration:
 
 ```hcl
-locals {
-  # Centralized module source configuration
-  git_base_url           = "git::git@github.com:"
-  tf_module_repository   = "your-org/terraform-modules"
-  tf_module_version_default = "v0.1.0"
-  tf_module_path_default = "modules/infrastructure-component"
-
-  # Dynamic module source generation
-  tf_module_source = format(
-    "%s%s//%s",
-    local.git_base_url,
-    local.tf_module_repository,
-    local.tf_module_path_default
-  )
-}
+# file located in infra/terragrunt/<env>/env.hcl
+env_cfg = read_terragrunt_config(find_in_parent_folders("env.hcl"))
 ```
 
-#### Source Management Benefits
+Automatically reads the stack configuration:
 
-- Centralized version control
-- Consistent module referencing
-- Flexible versioning
-- Simplified update process
+```hcl
+# file located in infra/terragrunt/<env>/<stack>/stack.hcl
+stack_cfg = read_terragrunt_config(find_in_parent_folders("stack.hcl"))
+```
+
+Automatically reads the global configuration from the root `config.hcl` file:
+
+```hcl
+# file located in infra/terragrunt/config.hcl
+cfg = read_terragrunt_config("${find_in_parent_folders("config.hcl")}")
+```
 
 ### 2. Intelligent Tagging System
 
-Multi-layered tagging strategy for comprehensive resource management:
+The tags are divided into three distinct layers:
+
+1. **Global Tags**: Tags that are applied to all resources.
+2. **Environment Tags**: Tags that are applied to all resources in the environment.
+3. **Unit Tags**: Tags that are applied to all resources in the unit.
+
+Each unit is also able to decorate with its own tags, like so:
 
 ```hcl
-locals {
-  # Hierarchical Tagging Approach
-  global_tags = {
-    ManagedBy     = "Terragrunt"
-    Architecture  = "Reference"
-  }
+unit_tags = {
+  Unit = "infrastructure-component"
+  Type = "generator"
+}
+```
 
-  env_tags = {
-    Environment = var.environment
-    Region      = var.region
-  }
+At the end, these tags are merged together, with a clear precedence strategy:
 
-  unit_tags = {
-    Unit = "infrastructure-component"
-    Type = "generator"
-  }
+```hcl
+  # 🔗 TAG SOURCE AGGREGATION
+  # Collect tags from different configuration levels
+  env_tags    = local.env_cfg.locals.tags
+  global_tags = local.cfg.locals.tags
+  stack_tags  = local.stack_cfg.locals.tags
 
-  # Merged tags with clear precedence
+  # 🧩 FINAL TAG COMPOSITION
+  # Merge tags with a clear precedence strategy
+  # Precedence: Unit Tags > Environment Tags > Global Tags
   all_tags = merge(
-    local.global_tags,
     local.env_tags,
-    local.unit_tags
+    local.unit_tags,
+    local.global_tags,
+    local.stack_tags
   )
-}
 ```
 
-#### Tagging Advantages
+This way, each unit can be tagged with its own tags, while still benefiting from the global tags and environment tags.
 
-- Consistent resource identification
-- Flexible tag management
-- Enhanced tracking capabilities
-- Cost allocation support
-- Clear ownership definition
+### 3. Git Module Source Management
 
-### 3. Dynamic Configuration Loading
+The module source is managed through a centralized configuration file in the `_config` directory (see [README.md](../_config/README.md) for more details).
 
-Leverages Terragrunt's advanced configuration capabilities:
+| Attribute | Description | Default Value | Environment Variable Override |
+|-----------|-------------|---------------|-------------------------------|
+| `git_base_url` | Base URL for GitHub repository access | `local.cfg.locals.cfg_git.git_base_urls.github` | N/A |
+| `git_base_url_local` | Base URL for local repository access | `local.cfg.locals.cfg_git.git_base_urls.local` | N/A |
+| `tf_module_repository` | GitHub repository path for the Terraform module | `"Excoriate/terraform-aws-codeartifact"` | N/A |
+| `tf_module_path_default` | Default path within the repository where the module is located | `"modules/domain-permissions"` | N/A |
+| `tf_module_version_default` | Default version tag of the module | `"v1.1.2"` | `TG_STACK_TF_MODULE_<MODULE_NAME>_VERSION_OVERRIDE` |
 
-```hcl
-locals {
-  # Hierarchical configuration resolution
-  global_config = read_terragrunt_config(find_in_parent_folders("global.hcl", ""))
-  env_config    = read_terragrunt_config(find_in_parent_folders("env.hcl", ""))
-  stack_config  = read_terragrunt_config(find_in_parent_folders("stack.hcl", ""))
-}
-```
+This configuration allows for quick iterations, and local overrides for troubleshooting and debugging.
 
-#### Configuration Management Benefits
+>NOTE: On each run, the module's version is echoed to the console for visibility.
 
-- Hierarchical configuration control
-- Environment-specific customization
-- Single source of truth
-- Flexible override mechanisms
-
-### 4. Dependency Management
-
-Robust dependency resolution and mocking:
-
-```hcl
-dependency "prerequisite_module" {
-  config_path = "../dependent-module"
-
-  mock_outputs = {
-    # Provides predictable outputs for planning
-    module_output = "mock-value"
-  }
-}
-```
-
-#### Dependency Handling Advantages
-
-- Explicit dependency declaration
-- Validation-friendly mock outputs
-- Controlled module interactions
-- Simplified testing workflows
-
-## Integration Mechanism 🔗
-
-Child Terragrunt configurations include shared units using a standardized approach:
-
-```hcl
-include "shared" {
-  path           = "${get_terragrunt_dir()}/../../../_shared/_units/component.hcl"
-  expose         = true
-  merge_strategy = "deep"
-}
-```
-
-## Best Practices 🌟
-
-### 1. Module Management
-
-- Use semantic versioning
-- Maintain stable module interfaces
-- Document breaking changes
-- Implement comprehensive input validation
-
-### 2. Configuration Design
-
-- Maintain focused, modular units
-- Follow consistent naming conventions
-- Implement clear tagging strategies
-- Document configuration purpose and usage
-
-### 3. Dependency Handling
-
-- Define explicit, clear dependencies
-- Provide meaningful mock outputs
-- Document inter-module relationships
-- Implement defensive configuration checks
-
-## Troubleshooting 🛠️
-
-### Common Resolution Strategies
-
-1. **Module Source Verification**
-
-   - Validate git repository access
-   - Confirm module path accuracy
-   - Check version constraint compatibility
-
-2. **Configuration Loading Diagnostics**
-
-   - Verify file path correctness
-   - Validate environment variable configurations
-   - Check configuration syntax and structure
-
-3. **Dependency Resolution**
-   - Validate dependency paths
-   - Verify mock output completeness
-   - Ensure output references are correct

--- a/infra/terragrunt/_shared/_units/age_generator.hcl
+++ b/infra/terragrunt/_shared/_units/age_generator.hcl
@@ -88,6 +88,7 @@ locals {
   # - Semantic version control
   #
   git_base_url              = local.cfg.locals.cfg_git.git_base_urls.local
+  git_base_url_local        = local.cfg.locals.cfg_git.git_base_urls.local
   tf_module_repository      = "your-org/terraform-modules.git"
   tf_module_version_default = get_env("TG_STACK_TF_MODULE_AGE_GENERATOR_VERSION_DEFAULT", "v0.1.0")
   tf_module_path_default    = "modules/age-generator"

--- a/infra/terragrunt/_shared/_units/dni_generator.hcl
+++ b/infra/terragrunt/_shared/_units/dni_generator.hcl
@@ -86,6 +86,7 @@ locals {
   # - Semantic version control
   #
   git_base_url              = local.cfg.locals.cfg_git.git_base_urls.local
+  git_base_url_local        = local.cfg.locals.cfg_git.git_base_urls.local
   tf_module_repository      = "your-org/terraform-modules.git"
   tf_module_version_default = get_env("TG_STACK_TF_MODULE_DNI_GENERATOR_VERSION_DEFAULT", "v0.1.0")
   tf_module_path_default    = "modules/dni-generator"

--- a/infra/terragrunt/_shared/_units/lastname_generator.hcl
+++ b/infra/terragrunt/_shared/_units/lastname_generator.hcl
@@ -88,6 +88,7 @@ locals {
   # - Semantic version control
   #
   git_base_url              = local.cfg.locals.cfg_git.git_base_urls.local
+  git_base_url_local        = local.cfg.locals.cfg_git.git_base_urls.local
   tf_module_repository      = "your-org/terraform-modules.git"
   tf_module_version_default = get_env("TG_STACK_TF_MODULE_LASTNAME_GENERATOR_VERSION_DEFAULT", "v0.1.0")
   tf_module_path_default    = "modules/lastname-generator"

--- a/infra/terragrunt/_shared/_units/name_generator.hcl
+++ b/infra/terragrunt/_shared/_units/name_generator.hcl
@@ -88,6 +88,7 @@ locals {
   # - Semantic version control
   #
   git_base_url              = local.cfg.locals.cfg_git.git_base_urls.local
+  git_base_url_local        = local.cfg.locals.cfg_git.git_base_urls.local
   tf_module_repository      = "your-org/terraform-modules.git"
   tf_module_version_default = get_env("TG_STACK_TF_MODULE_NAME_GENERATOR_VERSION_DEFAULT", "v0.1.0")
   tf_module_path_default    = "modules/name-generator"

--- a/infra/terragrunt/global/dni/age_generator/terragrunt.hcl
+++ b/infra/terragrunt/global/dni/age_generator/terragrunt.hcl
@@ -35,6 +35,8 @@ locals {
   # Enables flexible module sourcing for:
   # - Local development and testing
   # - Precise version control
+  # TODO: Switch this to use the tf_module_local_path when testing locally. If empty, it'll use the remote tf module set in the _shared/_units/<my_unit>.hcl file.
+  # tf_module_local_path       = "${include.shared.locals.git_base_url}/my-tf-module"
   tf_module_local_path       = "${include.shared.locals.git_base_url}/age-generator"
   tf_module_version_override = ""
   tf_module_version          = local.tf_module_version_override != "" ? local.tf_module_version_override : include.shared.locals.tf_module_version_default

--- a/infra/terragrunt/global/dni/dni_generator/terragrunt.hcl
+++ b/infra/terragrunt/global/dni/dni_generator/terragrunt.hcl
@@ -37,6 +37,8 @@ locals {
   # - Precise version control
   # - Consistent module referencing across infrastructure
   # ---------------------------------------------------------------------------------------------------------------------
+  # TODO: Switch this to use the tf_module_local_path when testing locally. If empty, it'll use the remote tf module set in the _shared/_units/<my_unit>.hcl file.
+  # tf_module_local_path       = "${include.shared.locals.git_base_url}/my-tf-module"
   tf_module_local_path       = "${include.shared.locals.git_base_url}/dni-generator"
   tf_module_version_override = ""
   tf_module_version          = local.tf_module_version_override != "" ? local.tf_module_version_override : include.shared.locals.tf_module_version_default

--- a/infra/terragrunt/global/dni/lastname_generator/terragrunt.hcl
+++ b/infra/terragrunt/global/dni/lastname_generator/terragrunt.hcl
@@ -37,6 +37,8 @@ locals {
   # - Precise version control
   # - Consistent module referencing across infrastructure
   # ---------------------------------------------------------------------------------------------------------------------
+  # TODO: Switch this to use the tf_module_local_path when testing locally. If empty, it'll use the remote tf module set in the _shared/_units/<my_unit>.hcl file.
+  # tf_module_local_path       = "${include.shared.locals.git_base_url}/my-tf-module"
   tf_module_local_path       = "${include.shared.locals.git_base_url}/lastname-generator"
   tf_module_version_override = ""
   tf_module_version          = local.tf_module_version_override != "" ? local.tf_module_version_override : include.shared.locals.tf_module_version_default

--- a/infra/terragrunt/global/dni/name_generator/terragrunt.hcl
+++ b/infra/terragrunt/global/dni/name_generator/terragrunt.hcl
@@ -37,6 +37,8 @@ locals {
   # - Precise version control
   # - Consistent module referencing across infrastructure
   # ---------------------------------------------------------------------------------------------------------------------
+  # TODO: Switch this to use the tf_module_local_path when testing locally. If empty, it'll use the remote tf module set in the _shared/_units/<my_unit>.hcl file.
+  # tf_module_local_path       = "${include.shared.locals.git_base_url}/my-tf-module"
   tf_module_local_path       = "${include.shared.locals.git_base_url}/name-generator"
   tf_module_version_override = ""
   tf_module_version          = local.tf_module_version_override != "" ? local.tf_module_version_override : include.shared.locals.tf_module_version_default

--- a/justfile
+++ b/justfile
@@ -146,8 +146,13 @@ tg-ci: (tg-hclvalidate) (tg-format)
 # Flexible recipe for running Terragrunt commands on individual units
 # Example: `just tg-run cmd=init`
 [working-directory:'infra/terragrunt']
-tg-run cmd="init":
-    @cd {{tg_env}}/{{tg_stack}}/{{tg_unit}} && terragrunt {{cmd}}
+tg-run env stack unit cmd="init":
+    @cd {{env}}/{{stack}}/{{unit}} && \
+    if [ "{{cmd}}" = "apply" ] || [ "{{cmd}}" = "destroy" ]; then \
+        terragrunt {{cmd}} --auto-approve; \
+    else \
+        terragrunt {{cmd}}; \
+    fi
 
 # 🌐 Run Terragrunt plan across all units in a stack
 # Provides a comprehensive view of potential infrastructure changes


### PR DESCRIPTION
This commit enhances the `tg-run` recipe in the `justfile` to automatically include the `--auto-approve` flag when running the `apply` or `destroy` Terragrunt commands. This change simplifies the execution of these commands, reducing the need for manual confirmation during the deployment process.