### PR TITLE
refactor/add-pipeline-dagger-enhancements

### DIFF
--- a/justfile
+++ b/justfile
@@ -232,3 +232,24 @@ pipeline-infra-tg-ci-static env="global" stack="dni": (pipeline-infra-build)
         --stack "{{stack}}"
 
     @echo "✅ Terragrunt CI checks completed successfully on environment: {{env}} | 📚 Stack: {{stack}}"
+
+# 🔨 Run a Terragrunt job on stacks, with custom arguments
+[working-directory:'pipeline/infra']
+pipeline-infra-tg-stack env="dev" stack="non-distributable" tg-cmd="validate" tg-cmd-args="--terragrunt-ignore-external-dependencies": (pipeline-infra-build)
+    @echo "🔄 Running Terragrunt stack through Dagger"
+    @echo "🌍 Environment: {{env}} | 📚 Stack: {{stack}}"
+    @echo "🔨 Terragrunt command: {{tg-cmd}}"
+    @echo "🔨 Terragrunt command arguments: {{tg-cmd-args}}"
+    @dagger call job-tg-stack \
+        --aws-region eu-west-1 \
+        --aws-access-key-id env:AWS_ACCESS_KEY_ID \
+        --aws-secret-access-key env:AWS_SECRET_ACCESS_KEY \
+        --load-dot-env \
+        --no-cache \
+        --environment "{{env}}" \
+        --stack "{{stack}}" \
+        --git-ssh $SSH_AUTH_SOCK \
+        --tg-cmd "{{tg-cmd}}" \
+        --tg-cmd-args "{{tg-cmd-args}}"
+
+    @echo "✅ Terragrunt stack completed successfully on environment: {{env}} | 📚 Stack: {{stack}}"

--- a/pipeline/infra/cd_tg.go
+++ b/pipeline/infra/cd_tg.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"dagger/infra/internal/dagger"
+	"fmt"
+)
+
+func (m *Infra) JobCDTgStack(
+	// Context is the context for managing the operation's lifecycle
+	// +optional
+	ctx context.Context,
+	// awsRegion is the AWS region to use for the remote backend.
+	// +optional
+	awsRegion string,
+	// awsAccessKeyID is the AWS access key ID.
+	// +optional
+	awsAccessKeyID *dagger.Secret,
+	// awsSecretAccessKey is the AWS secret access key.
+	// +optional
+	awsSecretAccessKey *dagger.Secret,
+	// loadDotEnv is a flag to enable source .env files from the local directory.
+	// +optional
+	loadDotEnv bool,
+	// NoCache is a flag to disable caching of the container.
+	// +optional
+	noCache bool,
+	// envVars are the environment variables that will be used to run the Terragrunt commands.
+	// +optional
+	envVars []string,
+	// stack is the stack to run the Terragrunt commands.
+	stack string,
+	// environment is the environment to run the Terragrunt commands.
+	environment string,
+	// gitSSH is a flag to enable SSH for the container.
+	// +optional
+	gitSSH *dagger.Socket,
+	// runApply is a flag to run the apply command.
+	// +optional
+	runApply bool,
+	// runDestroy is a flag to run the destroy command.
+	// +optional
+	runDestroy bool,
+	// runPlan is a flag to run the plan command.
+	// +optional
+	runPlan bool,
+) (string, error) {
+	var jobStackOut string
+	var jobStackErr error
+
+	if !runApply && !runDestroy && !runPlan {
+		return "", fmt.Errorf("either --run-apply (runApply) or --run-destroy (runDestroy) or --run-plan (runPlan) must be set to true")
+	}
+
+	if runApply && runDestroy {
+		return "", fmt.Errorf("cannot set both --run-apply (runApply) and --run-destroy (runDestroy) to true")
+	}
+
+	if runPlan && runApply {
+		return "", fmt.Errorf("cannot set both --run-plan (runPlan) and --run-apply (runApply) to true")
+	}
+
+	if runPlan && runDestroy {
+		return "", fmt.Errorf("cannot set both --run-plan (runPlan) and --run-destroy (runDestroy) to true")
+	}
+
+	if runApply {
+		jobStackOut, jobStackErr = m.JobTgStack(ctx,
+			stack,
+			awsRegion,
+			awsAccessKeyID,
+			awsSecretAccessKey,
+			loadDotEnv,
+			noCache,
+			envVars,
+			environment,
+			gitSSH,
+			[]string{"apply"},
+			[]string{"-auto-approve"},
+			nil,
+		)
+	} else if runDestroy {
+		jobStackOut, jobStackErr = m.JobTgStack(ctx,
+			stack,
+			awsRegion,
+			awsAccessKeyID,
+			awsSecretAccessKey,
+			loadDotEnv,
+			noCache,
+			envVars,
+			environment,
+			gitSSH,
+			[]string{"destroy"},
+			[]string{"-auto-approve"},
+			nil,
+		)
+	} else if runPlan {
+		jobStackOut, jobStackErr = m.JobTgStack(ctx,
+			stack,
+			awsRegion,
+			awsAccessKeyID,
+			awsSecretAccessKey,
+			loadDotEnv,
+			noCache,
+			envVars,
+			environment,
+			gitSSH,
+			[]string{"plan"},
+			[]string{},
+			nil,
+		)
+	}
+
+	return jobStackOut, jobStackErr
+}

--- a/pipeline/infra/job_tg.go
+++ b/pipeline/infra/job_tg.go
@@ -197,6 +197,107 @@ func (m *Infra) JobTgExec(
 	return stdout, nil
 }
 
+// JobTgStack runs the Terragrunt commands for the specified stack.
+//
+// This function takes the following parameters:
+//   - ctx: The context for managing the operation's lifecycle.
+//   - stack: The stack name to check.
+//   - awsRegion: The AWS region to use for the remote backend.
+//   - awsAccessKeyID: The AWS access key ID.
+//   - awsSecretAccessKey: The AWS secret access key.
+//   - loadDotEnv: A flag to enable source .env files from the local directory.
+//   - noCache: A flag to disable caching of the container.
+//   - envVars: The environment variables that will be used to run the Terragrunt commands.
+//   - environment: The environment to run the Terragrunt commands.
+//   - gitSSH: A flag to enable SSH for the container.
+//   - tgCmds: The commands to run on the container.
+//
+// Returns:
+//   - string: The output of the Terragrunt commands.
+func (m *Infra) JobTgStack(
+	// Context is the context for managing the operation's lifecycle
+	// +optional
+	ctx context.Context,
+	// stack is the stack name to check.
+	stack string,
+	// awsRegion is the AWS region to use for the remote backend.
+	// +optional
+	awsRegion string,
+	// awsAccessKeyID is the AWS access key ID.
+	// +optional
+	awsAccessKeyID *dagger.Secret,
+	// awsSecretAccessKey is the AWS secret access key.
+	// +optional
+	awsSecretAccessKey *dagger.Secret,
+	// loadDotEnv is a flag to enable source .env files from the local directory.
+	// +optional
+	loadDotEnv bool,
+	// NoCache is a flag to disable caching of the container.
+	// +optional
+	noCache bool,
+	// envVars are the environment variables that will be used to run the Terragrunt commands.
+	// +optional
+	envVars []string,
+	// environment is the environment to run the Terragrunt commands.
+	environment string,
+	// gitSSH is a flag to enable SSH for the container.
+	// +optional
+	gitSSH *dagger.Socket,
+	// tgCmd is the command to run on the container.
+	tgCmd []string,
+	// tgCmdArgs is the arguments to run on the command.
+	// +optional
+	tgCmdArgs []string,
+) (string, error) {
+	baseCtr, baseCtrErr := m.JobTg(ctx,
+		// TODO: add the remote state bucket and lock table
+		"",
+		"",
+		awsRegion,
+		awsAccessKeyID,
+		awsSecretAccessKey,
+		nil,
+		loadDotEnv,
+		noCache,
+		envVars,
+		"",
+		"",
+		gitSSH,
+	)
+
+	if len(tgCmd) == 0 {
+		return "", WrapErrorf(nil, "no commands to run for stack %s", stack)
+	}
+
+	tgCmd = append([]string{"terragrunt", "run-all"}, tgCmd...)
+
+	if baseCtrErr != nil {
+		return "", WrapErrorf(baseCtrErr, "failed to create base jobTg container for the job tg-stack %s", stack)
+	}
+
+	// Define the working directory for this unit
+	tgWorkDir := getTerragruntExecutionPathForStacks(environment, stack)
+
+	if len(tgCmdArgs) > 0 {
+		tgCmd = append(tgCmd, tgCmdArgs...)
+	}
+
+	tgCmd = append(tgCmd, "--working-dir", tgWorkDir)
+
+	// Add the commands, and the working directory to the container
+	baseCtr = baseCtr.
+		WithExec(tgCmd)
+
+	tgCmdOut, tgCmdErr := baseCtr.
+		Stdout(ctx)
+
+	if tgCmdErr != nil {
+		return "", WrapErrorf(tgCmdErr, "failed to run terragrunt commands for stack %s", stack)
+	}
+
+	return tgCmdOut, nil
+}
+
 func executeDaggerCtrAsync(
 	ctx context.Context,
 	resultChan chan<- JobResult,

--- a/pipeline/infra/job_tg.go
+++ b/pipeline/infra/job_tg.go
@@ -248,6 +248,9 @@ func (m *Infra) JobTgStack(
 	// tgCmdArgs is the arguments to run on the command.
 	// +optional
 	tgCmdArgs []string,
+	// gitlabToken is the Gitlab token.
+	// +optional
+	gitlabTfToken *dagger.Secret,
 ) (string, error) {
 	baseCtr, baseCtrErr := m.JobTg(ctx,
 		// TODO: add the remote state bucket and lock table
@@ -256,7 +259,7 @@ func (m *Infra) JobTgStack(
 		awsRegion,
 		awsAccessKeyID,
 		awsSecretAccessKey,
-		nil,
+		gitlabTfToken,
 		loadDotEnv,
 		noCache,
 		envVars,

--- a/pipeline/infra/utils.go
+++ b/pipeline/infra/utils.go
@@ -71,6 +71,18 @@ func getTerragruntExecutionPath(env, layer, unit string) string {
 	return filepath.Join(configRefArchRootPath, env, layer, unit)
 }
 
+func getTerragruntExecutionPathForStacks(env, layer string) string {
+	if env == "" {
+		env = defaultRefArchEnv
+	}
+
+	if layer == "" {
+		layer = defaulttRefArchLayer
+	}
+
+	return filepath.Join(configRefArchRootPath, env, layer)
+}
+
 func getTerraformModulesExecutionPath(moduleName string) string {
 	return filepath.Join(configRefArchATerraformModulesRootPath, moduleName)
 }


### PR DESCRIPTION
- Added `JobTgStack` to run Terragrunt commands on individual stacks with custom args, environment variables, and AWS credentials.
- Introduced helper `getTerragruntExecutionPathForStacks` to compute dynamic working directories for stack-specific Terragrunt runs.
- Added Justfile target `pipeline-infra-tg-stack` for easy CLI and CI invocation of stack-specific Terragrunt jobs.
- Added `JobCDTgStack` to provide a controlled interface for Terragrunt apply, destroy, or plan commands with validation to ensure only one operation runs at a time.
- Modified `JobTg` to accept an optional GitLab token for authenticating GitLab-backed Terraform modules.
- Maintained backward compatibility with no breaking changes; new functions and parameters are opt-in and extend existing pipeline infrastructure.